### PR TITLE
Fix death status tracking in game stats

### DIFF
--- a/server/game-manager.js
+++ b/server/game-manager.js
@@ -477,7 +477,7 @@ class GameManager {
                         name: p.loadout.name,
                         userId: userId,
                         code: p.loadout.code,
-                        died: p.robot.health <= 0,
+                        died: p.robot.state === 'destroyed',
                         kills: p.robot.kills || 0,
                         isBot: !p.socket // If no socket, it's a bot
                     };


### PR DESCRIPTION
## Summary
- fix player death tracking in GameManager

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68404b303580832d8de313481bedaa74