### PR TITLE
Fix redundant release call in loadouts route

### DIFF
--- a/server/routes/loadouts.js
+++ b/server/routes/loadouts.js
@@ -121,7 +121,6 @@ router.post('/', async (req, res) => {
         if (snippetRes.rows.length === 0) {
             // If snippet not found, rollback and return error
             await client.query('ROLLBACK');
-            client.release(); // Release client before returning
             console.log(`[API Loadouts POST] Snippet '${codeLoadoutName}' not found for user ${userId}.`);
             return res.status(400).json({ message: `Selected code snippet '${codeLoadoutName}' not found.` });
         }


### PR DESCRIPTION
## Summary
- remove unnecessary `client.release()` call in POST /api/loadouts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684058c333a0832d9130738f01b28331